### PR TITLE
Disable staticcheck and gosimple

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,8 @@ dep:
 buildit:
 	go build -tags static -o event-router main.go
 
-build: staticcheck gosimple buildit
+# build: staticcheck gosimple buildit
+build: buildit
 
 install: staticcheck gosimple
 	go install -tags static


### PR DESCRIPTION
For some reason the builder container does not have the dependnecies required for these. Need to add them in and add these back in if necessary.